### PR TITLE
Set version in pyproject.toml instead of dynamically in package code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VS Code project settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,6 @@ venv.bak/
 .spyderproject
 .spyproject
 
-# VS Code project settings
-.vscode
 
 # Rope project settings
 .ropeproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gridfit"
+version = "0.2.0"
 description = "..."
 readme = "README.md"
 authors = [
@@ -29,8 +30,6 @@ dependencies = [
     "matplotlib",
 ]
 
-dynamic = ["version"]
-
 [project.urls]
 repository = "https://github.com/nelsond/gridfit"
 
@@ -41,9 +40,6 @@ dev = [
     "pytest-cov==3.0.0",
     "mypy>=0.971",
 ]
-
-[tool.setuptools.dynamic]
-version = {attr = "gridfit.__version__"}
 
 [tool.mypy]
 plugins = "numpy.typing.mypy_plugin"

--- a/src/gridfit/version.py
+++ b/src/gridfit/version.py
@@ -1,1 +1,2 @@
-__version__ = '0.2.0'
+import importlib.metadata
+__version__ = importlib.metadata.version(__package__)


### PR DESCRIPTION
Pyproject.toml is fully static then. Enables use of other build systems.
